### PR TITLE
Fix workflow paths

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./risk-register
+        working-directory: .
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-          cache-dependency-path: ./risk-register/package-lock.json
+          cache-dependency-path: ./package-lock.json
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:
@@ -69,7 +69,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ./risk-register/.next/cache
+            ./.next/cache
           # Generate a new cache whenever packages or source files change.
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
@@ -82,7 +82,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./risk-register/out
+          path: ./out
 
   # Deployment job
   deploy:


### PR DESCRIPTION
## Summary
- fix default working directory in `nextjs.yml`
- correct paths to package lock, cache, and artifact

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685af34616a883259f9075d5d6e4b9bf