### PR TITLE
Remove unused Inter font import

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,7 +1,4 @@
 import { Html, Head, Main, NextScript } from "next/document";
-import { Inter } from "next/font/google";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export default function Document() {
   return (


### PR DESCRIPTION
## Summary
- fix lint error in `_document.tsx` by removing the unused Inter font import and variable

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b11ccfa5c8325a0e88484fa476250