### PR TITLE
Fix CSV export column order

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -134,22 +134,22 @@ export default function Home() {
     : risks;
 
   const exportCSV = () => {
-    const header = Object.keys(risks[0] || {}).join(',');
+    const headers = [
+      'id',
+      'description',
+      'category',
+      'probability',
+      'impact',
+      'owner',
+      'mitigation',
+      'status',
+      'dateIdentified',
+      'lastReviewed',
+    ] as const;
     const rows = risks.map((r) =>
-      [
-        r.id,
-        r.description,
-        r.category,
-        r.probability,
-        r.impact,
-        r.owner,
-        r.mitigation,
-        r.status,
-        r.dateIdentified,
-        r.lastReviewed,
-      ].join(',')
+      headers.map((h) => String(r[h])).join(',')
     );
-    const csv = [header, ...rows].join('\n');
+    const csv = [headers.join(','), ...rows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- fix header generation for CSV export so column order matches row data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685becef9f808325a7b4a692f77bc056