### PR TITLE
Add risk timeline component

### DIFF
--- a/data/risks.json
+++ b/data/risks.json
@@ -9,6 +9,8 @@
     "owner": "joe",
     "mitigation": "action plan",
     "status": "In-Progress",
+    "startDate": "2025-06-24",
+    "endDate": "2025-07-24",
     "dateIdentified": "2025-06-24T17:46:31.639Z"
   },
   {
@@ -21,6 +23,8 @@
     "owner": "",
     "mitigation": "",
     "status": "Open",
+    "startDate": "2025-06-24",
+    "endDate": "2025-07-24",
     "dateIdentified": "2025-06-24T17:47:07.215Z"
   },
   {
@@ -33,6 +37,8 @@
     "owner": "",
     "mitigation": "",
     "status": "Open",
+    "startDate": "2025-06-24",
+    "endDate": "2025-07-24",
     "dateIdentified": "2025-06-24T17:47:39.748Z"
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.10.1",
+        "chart.js": "^4.5.0",
         "next": "15.3.4",
         "prisma": "^6.10.1",
         "react": "^19.0.0",
@@ -768,6 +769,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
@@ -2418,6 +2425,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chownr": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.10.1",
+    "chart.js": "^4.5.0",
     "next": "15.3.4",
     "prisma": "^6.10.1",
     "react": "^19.0.0",

--- a/src/components/RiskHistoryTimeline.tsx
+++ b/src/components/RiskHistoryTimeline.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Risk } from '@/types/risk';
+import { ProjectMeta } from '@/types/project';
+
+interface Props {
+  risks: Risk[];
+  project: ProjectMeta;
+}
+
+const statuses: Risk['status'][] = ['Open', 'In-Progress', 'Mitigated', 'Accepted'];
+
+function addStep(date: Date, step: 'week' | 'month' | 'year') {
+  const d = new Date(date);
+  if (step === 'week') d.setDate(d.getDate() + 7);
+  else if (step === 'month') d.setMonth(d.getMonth() + 1);
+  else d.setFullYear(d.getFullYear() + 1);
+  return d;
+}
+
+export default function RiskHistoryTimeline({ risks, project }: Props) {
+  if (!project.startDate || !project.endDate) return null;
+  const start = new Date(project.startDate);
+  const end = new Date(project.endDate);
+  if (end <= start) return null;
+  const diffDays = (end.getTime() - start.getTime()) / 86400000;
+  let step: 'week' | 'month' | 'year';
+  if (diffDays <= 120) step = 'week';
+  else if (diffDays <= 730) step = 'month';
+  else step = 'year';
+  const dates: Date[] = [];
+  for (let d = new Date(start); d <= end; d = addStep(d, step)) {
+    dates.push(new Date(d));
+  }
+  const series = statuses.map((status) => {
+    return dates.map((date) => {
+      const active = risks.filter(
+        (r) => new Date(r.startDate) <= date && new Date(r.endDate) >= date && r.status === status,
+      );
+      const avg =
+        active.length === 0
+          ? 0
+          : active.reduce((s, r) => s + r.probability * r.impact, 0) / active.length;
+      return { date, value: avg };
+    });
+  });
+  const width = 600;
+  const height = 300;
+  const x = (score: number) => (score / 25) * width;
+  const y = (date: Date) => ((date.getTime() - start.getTime()) / (end.getTime() - start.getTime())) * height;
+  const colors = ['#ef4444', '#f59e0b', '#10b981', '#3b82f6'];
+
+  return (
+    <div className="overflow-auto">
+      <svg width={width} height={height} className="border">
+        {/* axes */}
+        <line x1={0} y1={0} x2={0} y2={height} stroke="#000" />
+        <line x1={0} y1={height} x2={width} y2={height} stroke="#000" />
+        {/* y-axis labels */}
+        {dates.map((d, i) => (
+          <g key={i}>
+            <line x1={0} y1={y(d)} x2={-5} y2={y(d)} stroke="#000" />
+            <text x={-8} y={y(d) + 4} textAnchor="end" fontSize="10">
+              {d.toISOString().split('T')[0]}
+            </text>
+          </g>
+        ))}
+        {/* x-axis labels */}
+        {[0, 5, 10, 15, 20, 25].map((s) => (
+          <g key={s}>
+            <line x1={x(s)} y1={height} x2={x(s)} y2={height + 5} stroke="#000" />
+            <text x={x(s)} y={height + 15} textAnchor="middle" fontSize="10">
+              {s}
+            </text>
+          </g>
+        ))}
+        {series.map((data, idx) => (
+          <polyline
+            key={statuses[idx]}
+            fill="none"
+            stroke={colors[idx]}
+            strokeWidth={2}
+            points={data.map((p) => `${x(p.value)},${y(p.date)}`).join(' ')}
+          />
+        ))}
+      </svg>
+      <div className="flex space-x-2 pt-1 text-sm">
+        {statuses.map((s, i) => (
+          <div key={s} className="flex items-center space-x-1">
+            <span className="w-3 h-3 inline-block" style={{ background: colors[i] }} />
+            <span>{s}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Risk, RiskInput } from '@/types/risk';
 import { ProjectMeta } from '@/types/project';
+import RiskHistoryTimeline from '@/components/RiskHistoryTimeline';
 import * as XLSX from 'xlsx';
 
 export default function Home() {
@@ -15,6 +16,8 @@ export default function Home() {
     owner: '',
     mitigation: '',
     status: 'Open',
+    startDate: new Date().toISOString(),
+    endDate: new Date().toISOString(),
     dateIdentified: new Date().toISOString(),
   });
   const [errors, setErrors] = useState<Partial<Record<keyof RiskInput, string>>>({});
@@ -68,6 +71,10 @@ export default function Home() {
       errs.probability = 'Probability must be 1-5';
     if (form.impact < 1 || form.impact > 5)
       errs.impact = 'Impact must be 1-5';
+    if (!form.startDate) errs.startDate = 'Start date is required';
+    if (!form.endDate) errs.endDate = 'End date is required';
+    if (form.startDate && form.endDate && form.startDate > form.endDate)
+      errs.endDate = 'End date must be after start date';
     setErrors(errs);
     return Object.keys(errs).length === 0;
   };
@@ -111,6 +118,8 @@ export default function Home() {
       owner: '',
       mitigation: '',
       status: 'Open',
+      startDate: new Date().toISOString(),
+      endDate: new Date().toISOString(),
       dateIdentified: new Date().toISOString(),
     });
     setEditingId(null);
@@ -135,6 +144,8 @@ export default function Home() {
       owner: '',
       mitigation: '',
       status: 'Open',
+      startDate: new Date().toISOString(),
+      endDate: new Date().toISOString(),
       dateIdentified: new Date().toISOString(),
     });
     setErrors({});
@@ -250,6 +261,8 @@ export default function Home() {
           owner: (r['owner'] as string) || '',
           mitigation: (r['mitigation'] as string) || '',
           status: (r['status'] as Risk['status']) || 'Open',
+          startDate: (r['startDate'] as string) || new Date().toISOString(),
+          endDate: (r['endDate'] as string) || new Date().toISOString(),
           dateIdentified: (r['dateIdentified'] as string) || new Date().toISOString(),
           lastReviewed: (r['lastReviewed'] as string) || new Date().toISOString(),
         }));
@@ -353,6 +366,32 @@ export default function Home() {
               <option>Mitigated</option>
               <option>Accepted</option>
             </select>
+            <label htmlFor="startDate" className="block text-sm font-medium">
+              Start Date
+            </label>
+            <input
+              id="startDate"
+              type="date"
+              className="border p-1 w-full"
+              value={form.startDate.split('T')[0]}
+              onChange={(e) => setForm({ ...form, startDate: e.target.value })}
+            />
+            {errors.startDate && (
+              <p className="text-red-500 text-sm">{errors.startDate}</p>
+            )}
+            <label htmlFor="endDate" className="block text-sm font-medium">
+              End Date
+            </label>
+            <input
+              id="endDate"
+              type="date"
+              className="border p-1 w-full"
+              value={form.endDate.split('T')[0]}
+              onChange={(e) => setForm({ ...form, endDate: e.target.value })}
+            />
+            {errors.endDate && (
+              <p className="text-red-500 text-sm">{errors.endDate}</p>
+            )}
             <div className="flex gap-2">
               <label htmlFor="probability">Prob</label>
               <input
@@ -471,6 +510,10 @@ export default function Home() {
         </div>
       </div>
       <div className="bg-white rounded-lg shadow p-4">
+        <h2 className="font-semibold mb-2">Risk History Timeline</h2>
+        <RiskHistoryTimeline risks={risks} project={meta} />
+      </div>
+      <div className="bg-white rounded-lg shadow p-4">
         <div className="flex items-center justify-between">
           <h2 className="font-semibold">Risks</h2>
           <div className="space-x-2">
@@ -531,14 +574,16 @@ export default function Home() {
         </div>
         <table className="w-full border rounded">
           <thead>
-            <tr className="bg-gray-100">
-              <th className="border p-1">ID</th>
-              <th className="border p-1">Description</th>
-              <th className="border p-1">Category</th>
-              <th className="border p-1">Prob</th>
-              <th className="border p-1">Impact</th>
-              <th className="border p-1">Actions</th>
-            </tr>
+          <tr className="bg-gray-100">
+            <th className="border p-1">ID</th>
+            <th className="border p-1">Description</th>
+            <th className="border p-1">Category</th>
+            <th className="border p-1">Prob</th>
+            <th className="border p-1">Impact</th>
+            <th className="border p-1">Start</th>
+            <th className="border p-1">End</th>
+            <th className="border p-1">Actions</th>
+          </tr>
           </thead>
           <tbody>
             {filteredRisks.map((r) => (
@@ -548,6 +593,8 @@ export default function Home() {
                 <td className="border p-1">{r.category}</td>
                 <td className="border p-1">{r.probability}</td>
                 <td className="border p-1">{r.impact}</td>
+                <td className="border p-1">{r.startDate.split('T')[0]}</td>
+                <td className="border p-1">{r.endDate.split('T')[0]}</td>
                 <td className="border p-1 space-x-2">
                   <button onClick={() => startEdit(r)} className="text-blue-600">Edit</button>
                   <button onClick={() => removeRisk(r.id)} className="text-red-600">Delete</button>

--- a/src/types/risk.ts
+++ b/src/types/risk.ts
@@ -7,6 +7,8 @@ export interface Risk {
   owner: string;
   mitigation: string;
   status: 'Open' | 'In-Progress' | 'Mitigated' | 'Accepted';
+  startDate: string; // ISO
+  endDate: string; // ISO
   dateIdentified: string; // ISO
   lastReviewed: string; // ISO
 }


### PR DESCRIPTION
## Summary
- introduce `startDate` and `endDate` to risk schema
- collect those fields in the form
- validate dates in risk editor
- add line chart component `RiskHistoryTimeline`
- display risk start and end in table
- include sample dates in fixture data

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c0d84ff408325859a485053969a6b