### PR TITLE
Add risk response and workflow notes

### DIFF
--- a/data/risks.json
+++ b/data/risks.json
@@ -9,6 +9,14 @@
     "owner": "joe",
     "mitigation": "action plan",
     "status": "In-Progress",
+    "response": "Mitigate",
+    "statusHistory": [
+      {
+        "date": "2025-06-24T17:47:07.213Z",
+        "status": "In-Progress",
+        "note": "Initial entry"
+      }
+    ],
     "startDate": "2025-06-24",
     "endDate": "2025-07-24",
     "dateIdentified": "2025-06-24T17:46:31.639Z"
@@ -23,6 +31,14 @@
     "owner": "",
     "mitigation": "",
     "status": "Open",
+    "response": "Accept",
+    "statusHistory": [
+      {
+        "date": "2025-06-24T17:47:39.747Z",
+        "status": "Open",
+        "note": "Initial entry"
+      }
+    ],
     "startDate": "2025-06-24",
     "endDate": "2025-07-24",
     "dateIdentified": "2025-06-24T17:47:07.215Z"
@@ -37,6 +53,14 @@
     "owner": "",
     "mitigation": "",
     "status": "Open",
+    "response": "Transfer",
+    "statusHistory": [
+      {
+        "date": "2025-06-24T17:47:40.239Z",
+        "status": "Open",
+        "note": "Initial entry"
+      }
+    ],
     "startDate": "2025-06-24",
     "endDate": "2025-07-24",
     "dateIdentified": "2025-06-24T17:47:39.748Z"

--- a/src/pages/api/risks/[id].ts
+++ b/src/pages/api/risks/[id].ts
@@ -24,7 +24,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   switch (req.method) {
     case 'PUT': {
-      const updated = { ...risks[index], ...req.body, lastReviewed: new Date().toISOString() };
+      const { statusNote, ...body } = req.body as Partial<Risk> & { statusNote?: string };
+      const existing = risks[index];
+      const history = [...existing.statusHistory];
+      if (body.status && body.status !== existing.status) {
+        history.push({
+          date: new Date().toISOString(),
+          status: body.status,
+          note: statusNote || '',
+        });
+      }
+      const updated = { ...existing, ...body, lastReviewed: new Date().toISOString(), statusHistory: history };
       risks[index] = updated;
       await writeRisks(risks);
       res.status(200).json(updated);

--- a/src/pages/api/risks/index.ts
+++ b/src/pages/api/risks/index.ts
@@ -28,6 +28,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         id: Date.now().toString(),
         lastReviewed: new Date().toISOString(),
         ...input,
+        statusHistory: [
+          {
+            date: new Date().toISOString(),
+            status: input.status,
+            note: '',
+          },
+        ],
       };
       risks.push(newRisk);
       await writeRisks(risks);

--- a/src/types/risk.ts
+++ b/src/types/risk.ts
@@ -1,3 +1,11 @@
+export type RiskStatus = 'Open' | 'In-Progress' | 'Mitigated' | 'Accepted';
+
+export interface StatusChange {
+  date: string; // ISO timestamp
+  status: RiskStatus;
+  note: string;
+}
+
 export interface Risk {
   id: string;
   description: string;
@@ -6,11 +14,13 @@ export interface Risk {
   impact: number; // 1-5
   owner: string;
   mitigation: string;
-  status: 'Open' | 'In-Progress' | 'Mitigated' | 'Accepted';
+  status: RiskStatus;
+  response: 'Avoid' | 'Mitigate' | 'Transfer' | 'Accept';
+  statusHistory: StatusChange[];
   startDate: string; // ISO
   endDate: string; // ISO
   dateIdentified: string; // ISO
   lastReviewed: string; // ISO
 }
 
-export type RiskInput = Omit<Risk, 'id' | 'lastReviewed'>;
+export type RiskInput = Omit<Risk, 'id' | 'lastReviewed' | 'statusHistory'>;


### PR DESCRIPTION
## Summary
- extend risk model with `response` and `statusHistory`
- allow selecting a response type in the UI
- record a note when status changes
- store new fields when importing/exporting and via API
- update seed data with sample responses

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685c12771f848325a8676e364885cff1