### PR TITLE
Make risk end date optional

### DIFF
--- a/data/risks.json
+++ b/data/risks.json
@@ -17,9 +17,8 @@
         "note": "Initial entry"
       }
     ],
-    "startDate": "2025-06-24",
-    "endDate": "2025-07-24",
-    "dateIdentified": "2025-06-24T17:46:31.639Z"
+    "dateIdentified": "2025-06-24T17:46:31.639Z",
+    "dateResolved": "2025-07-24"
   },
   {
     "id": "1750787259747",
@@ -39,9 +38,8 @@
         "note": "Initial entry"
       }
     ],
-    "startDate": "2025-06-24",
-    "endDate": "2025-07-24",
-    "dateIdentified": "2025-06-24T17:47:07.215Z"
+    "dateIdentified": "2025-06-24T17:47:07.215Z",
+    "dateResolved": "2025-07-24"
   },
   {
     "id": "1750787260239",
@@ -61,8 +59,7 @@
         "note": "Initial entry"
       }
     ],
-    "startDate": "2025-06-24",
-    "endDate": "2025-07-24",
-    "dateIdentified": "2025-06-24T17:47:39.748Z"
+    "dateIdentified": "2025-06-24T17:47:39.748Z",
+    "dateResolved": "2025-07-24"
   }
 ]

--- a/public/risks.json
+++ b/public/risks.json
@@ -9,7 +9,8 @@
     "owner": "joe",
     "mitigation": "action plan",
     "status": "In-Progress",
-    "dateIdentified": "2025-06-24T17:46:31.639Z"
+    "dateIdentified": "2025-06-24T17:46:31.639Z",
+    "dateResolved": ""
   },
   {
     "id": "1750787259747",
@@ -21,7 +22,8 @@
     "owner": "",
     "mitigation": "",
     "status": "Open",
-    "dateIdentified": "2025-06-24T17:47:07.215Z"
+    "dateIdentified": "2025-06-24T17:47:07.215Z",
+    "dateResolved": ""
   },
   {
     "id": "1750787260239",
@@ -33,6 +35,7 @@
     "owner": "",
     "mitigation": "",
     "status": "Open",
-    "dateIdentified": "2025-06-24T17:47:39.748Z"
+    "dateIdentified": "2025-06-24T17:47:39.748Z",
+    "dateResolved": ""
   }
 ]

--- a/src/components/RiskHistoryTimeline.tsx
+++ b/src/components/RiskHistoryTimeline.tsx
@@ -35,10 +35,9 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
     return dates.map((date) => {
       const active = risks.filter(
         (r) =>
-          r.startDate &&
-          r.endDate &&
-          new Date(r.startDate) <= date &&
-          new Date(r.endDate) >= date &&
+          r.dateIdentified &&
+          (!r.dateResolved || new Date(r.dateResolved) >= date) &&
+          new Date(r.dateIdentified) <= date &&
           r.status === status,
       );
       const avg =

--- a/src/types/risk.ts
+++ b/src/types/risk.ts
@@ -17,9 +17,8 @@ export interface Risk {
   status: RiskStatus;
   response: 'Avoid' | 'Mitigate' | 'Transfer' | 'Accept';
   statusHistory: StatusChange[];
-  startDate: string; // ISO
-  endDate: string; // ISO
   dateIdentified: string; // ISO
+  dateResolved?: string; // ISO
   lastReviewed: string; // ISO
 }
 


### PR DESCRIPTION
## Summary
- update `Risk` type to use optional `dateResolved`
- adapt risk form and validation for optional end date
- rename start/end date fields in UI to "Date Identified"/"Date Resolved"
- update timeline and data files for new field names

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c16d63a048325b3b9b9168e4e8e7b