### PR TITLE
Improve risk matrix layout

### DIFF
--- a/src/components/AggregatedRiskPanel.tsx
+++ b/src/components/AggregatedRiskPanel.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import AggregatedRisk from './AggregatedRisk';
+
+interface Props {
+  score: number;
+}
+
+export default function AggregatedRiskPanel({ score }: Props) {
+  return (
+    <div className="bg-white rounded-lg shadow p-4">
+      <h2 className="font-semibold mb-2">Aggregated Risk</h2>
+      <AggregatedRisk score={score} />
+    </div>
+  );
+}

--- a/src/components/RiskMatrixPanel.tsx
+++ b/src/components/RiskMatrixPanel.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Risk } from '@/types/risk';
+import RiskMatrix from './RiskMatrix';
+
+interface Props {
+  matrix: Record<number, Record<number, Risk[]>>;
+  filter: { prob: number; impact: number } | null;
+  onCellClick: (prob: number, impact: number) => void;
+}
+
+export default function RiskMatrixPanel({ matrix, filter, onCellClick }: Props) {
+  return (
+    <div className="bg-white rounded-lg shadow p-4 overflow-auto">
+      <h2 className="font-semibold mb-2">Risk Matrix</h2>
+      <RiskMatrix matrix={matrix} filter={filter} onCellClick={onCellClick} />
+    </div>
+  );
+}

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -4,8 +4,8 @@ import { useEffect, useRef, useState } from 'react';
 import { Risk } from '@/types/risk';
 import { ProjectMeta, Project } from '@/types/project';
 import RiskHistoryTimeline from '@/components/RiskHistoryTimeline';
-import RiskMatrix from '@/components/RiskMatrix';
-import AggregatedRisk from '@/components/AggregatedRisk';
+import RiskMatrixPanel from '@/components/RiskMatrixPanel';
+import AggregatedRiskPanel from '@/components/AggregatedRiskPanel';
 import * as XLSX from 'xlsx';
 
 export default function ProjectHome() {
@@ -212,15 +212,15 @@ export default function ProjectHome() {
       </nav>
       <main className="container mx-auto p-4 space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="bg-white rounded-lg shadow p-4 overflow-auto">
-            <h2 className="font-semibold mb-2">Risk Matrix</h2>
-            <RiskMatrix matrix={matrix} filter={filter} onCellClick={handleCellClick} />
+          <div className="space-y-4">
+            <RiskMatrixPanel
+              matrix={matrix}
+              filter={filter}
+              onCellClick={handleCellClick}
+            />
+            <AggregatedRiskPanel score={aggregatedScore} />
           </div>
           <div className="bg-white rounded-lg shadow p-4">
-            <h2 className="font-semibold mb-2">Aggregated Risk</h2>
-            <AggregatedRisk score={aggregatedScore} />
-          </div>
-          <div className="md:col-span-2 bg-white rounded-lg shadow p-4">
             <h2 className="font-semibold mb-2">Risk History Timeline</h2>
             <RiskHistoryTimeline risks={risks} project={meta} />
           </div>


### PR DESCRIPTION
## Summary
- add `RiskMatrixPanel` and `AggregatedRiskPanel` components
- group risk matrix and aggregated risk panels next to the timeline

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c303e4be08325b7f2098b41db3145