### PR TITLE
Move projects listing and add project validation

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,61 +1,19 @@
-import Link from 'next/link';
+import { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
-import { Project } from '@/types/project';
 
-export default function Projects() {
-  const [projects, setProjects] = useState<Project[]>([]);
+export default function Home() {
   const router = useRouter();
-
   useEffect(() => {
     const saved = typeof window !== 'undefined' && localStorage.getItem('projects');
-    if (saved) setProjects(JSON.parse(saved));
-  }, []);
-
-  const createProject = () => {
-    const id = Date.now().toString();
-    const newProject: Project = {
-      id,
-      meta: {
-        projectName: '',
-        projectManager: '',
-        sponsor: '',
-        startDate: '',
-        endDate: '',
-        riskPlan: '',
-      },
-      risks: [],
-    };
-    const updated = [...projects, newProject];
-    setProjects(updated);
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('projects', JSON.stringify(updated));
+    if (saved) {
+      const list = JSON.parse(saved) as { id: string }[];
+      if (list.length > 0) {
+        router.replace(`/project/${list[0].id}`);
+        return;
+      }
     }
-    router.push(`/project/${id}/settings`);
-  };
+    router.replace('/projects');
+  }, [router]);
 
-  return (
-    <div className="min-h-screen bg-gray-50 p-4">
-      <h1 className="text-xl font-semibold mb-4">Projects</h1>
-      <div className="space-y-2">
-        {projects.map((p) => (
-          <div
-            key={p.id}
-            className="bg-white rounded shadow p-3 flex justify-between items-center"
-          >
-            <span>{p.meta.projectName || 'Untitled Project'}</span>
-            <Link href={`/project/${p.id}`} className="text-blue-600">
-              Open
-            </Link>
-          </div>
-        ))}
-      </div>
-      <button
-        onClick={createProject}
-        className="mt-4 bg-indigo-600 text-white px-3 py-1 rounded"
-      >
-        New Project
-      </button>
-    </div>
-  );
+  return <p className="p-4">Redirecting...</p>;
 }

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -41,6 +41,9 @@ export default function ProjectHome() {
       if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
         setShowExportOptions(false);
       }
+      if (addRef.current && !addRef.current.contains(e.target as Node)) {
+        setShowAddOptions(false);
+      }
     };
     document.addEventListener('click', handler);
     return () => document.removeEventListener('click', handler);
@@ -126,7 +129,9 @@ export default function ProjectHome() {
   };
 
   const [showExportOptions, setShowExportOptions] = useState(false);
+  const [showAddOptions, setShowAddOptions] = useState(false);
   const exportRef = useRef<HTMLDivElement | null>(null);
+  const addRef = useRef<HTMLDivElement | null>(null);
 
   const fileInput = useRef<HTMLInputElement | null>(null);
 
@@ -193,14 +198,33 @@ export default function ProjectHome() {
       <nav className="bg-blue-950 text-white shadow">
         <div className="container mx-auto px-4 py-3 flex items-center justify-between">
           <h1 className="text-xl font-semibold">Risk Manager</h1>
-          <div className="space-x-2">
-            <Link
-              href={`/project/${pid}/risk/new`}
-              title="Add a Risk"
-              className="border px-2 py-1 rounded hover:bg-gray-100 text-black bg-white"
-            >
-              Add +
-            </Link>
+          <div className="space-x-2 relative">
+            <div className="inline-block" ref={addRef}>
+              <button
+                onClick={() => setShowAddOptions((p) => !p)}
+                className="border px-2 py-1 rounded hover:bg-gray-100 text-black bg-white"
+              >
+                Add +
+              </button>
+              {showAddOptions && (
+                <div className="absolute right-0 mt-1 w-32 bg-white border rounded shadow z-10">
+                  <Link
+                    href={`/project/${pid}/risk/new`}
+                    className="block px-3 py-1 hover:bg-gray-100"
+                    onClick={() => setShowAddOptions(false)}
+                  >
+                    Risk
+                  </Link>
+                  <Link
+                    href="/projects"
+                    className="block px-3 py-1 hover:bg-gray-100"
+                    onClick={() => setShowAddOptions(false)}
+                  >
+                    Project
+                  </Link>
+                </div>
+              )}
+            </div>
             <Link
               href={`/project/${pid}/settings`}
               className="border px-2 py-1 rounded hover:bg-gray-100 text-black bg-white"

--- a/src/pages/project/[pid]/settings.tsx
+++ b/src/pages/project/[pid]/settings.tsx
@@ -13,6 +13,7 @@ export default function Settings() {
     endDate: '',
     riskPlan: '',
   });
+  const [errors, setErrors] = useState<Partial<Record<keyof ProjectMeta, string>>>({});
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -33,7 +34,20 @@ export default function Settings() {
     }
   }, [router.isReady, pid]);
 
+  const validate = () => {
+    const errs: Partial<Record<keyof ProjectMeta, string>> = {};
+    if (!form.projectName.trim()) errs.projectName = 'Title is required';
+    if (!form.startDate) errs.startDate = 'Start date is required';
+    if (!form.endDate) errs.endDate = 'End date is required';
+    if (form.startDate && form.endDate && form.startDate > form.endDate) {
+      errs.endDate = 'End date must be after start date';
+    }
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
   const save = () => {
+    if (!validate()) return;
     if (!router.isReady) return;
     const saved = typeof window !== 'undefined' && localStorage.getItem('projects');
     const projects: Project[] = saved ? JSON.parse(saved) : [];
@@ -60,6 +74,7 @@ export default function Settings() {
           value={form.projectName}
           onChange={(e) => setForm({ ...form, projectName: e.target.value })}
         />
+        {errors.projectName && <p className="text-red-500 text-sm">{errors.projectName}</p>}
 
         <label htmlFor="projectManager" className="block text-sm font-medium">
           Project Manager
@@ -91,6 +106,7 @@ export default function Settings() {
           value={form.startDate}
           onChange={(e) => setForm({ ...form, startDate: e.target.value })}
         />
+        {errors.startDate && <p className="text-red-500 text-sm">{errors.startDate}</p>}
 
         <label htmlFor="endDate" className="block text-sm font-medium">
           End Date
@@ -102,6 +118,7 @@ export default function Settings() {
           value={form.endDate}
           onChange={(e) => setForm({ ...form, endDate: e.target.value })}
         />
+        {errors.endDate && <p className="text-red-500 text-sm">{errors.endDate}</p>}
 
         <label htmlFor="riskPlan" className="block text-sm font-medium">
           Risk Management Plan

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { Project } from '@/types/project';
+
+export default function Projects() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    const saved = typeof window !== 'undefined' && localStorage.getItem('projects');
+    if (saved) setProjects(JSON.parse(saved));
+  }, []);
+
+  const createProject = () => {
+    const id = Date.now().toString();
+    const newProject: Project = {
+      id,
+      meta: {
+        projectName: '',
+        projectManager: '',
+        sponsor: '',
+        startDate: '',
+        endDate: '',
+        riskPlan: '',
+      },
+      risks: [],
+    };
+    const updated = [...projects, newProject];
+    setProjects(updated);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('projects', JSON.stringify(updated));
+    }
+    router.push(`/project/${id}/settings`);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <h1 className="text-xl font-semibold mb-4">Projects</h1>
+      <div className="space-y-2">
+        {projects.map((p) => (
+          <div
+            key={p.id}
+            className="bg-white rounded shadow p-3 flex justify-between items-center"
+          >
+            <span>{p.meta.projectName || 'Untitled Project'}</span>
+            <Link href={`/project/${p.id}`} className="text-blue-600">
+              Open
+            </Link>
+          </div>
+        ))}
+      </div>
+      <button
+        onClick={createProject}
+        className="mt-4 bg-indigo-600 text-white px-3 py-1 rounded"
+      >
+        New Project
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- redirect home to first project or projects list
- move projects listing to `/projects`
- add dropdown menu for creating a risk or project
- validate project settings form for name and dates

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c330ab3ec8325a6b87dc919238e3a