### PR TITLE
Move aggregated risk panel above risk matrix

### DIFF
--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -237,12 +237,12 @@ export default function ProjectHome() {
       <main className="container mx-auto p-4 space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="space-y-4">
+            <AggregatedRiskPanel score={aggregatedScore} />
             <RiskMatrixPanel
               matrix={matrix}
               filter={filter}
               onCellClick={handleCellClick}
             />
-            <AggregatedRiskPanel score={aggregatedScore} />
           </div>
           <div className="bg-white rounded-lg shadow p-4">
             <h2 className="font-semibold mb-2">Risk History Timeline</h2>


### PR DESCRIPTION
## Summary
- reorder panels so aggregated risk appears before risk matrix on project page

## Testing
- `npm run lint`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685c36627fe88325b6903e48817adeb0