### PR TITLE
Improve risk timeline labels

### DIFF
--- a/src/components/RiskHistoryTimeline.tsx
+++ b/src/components/RiskHistoryTimeline.tsx
@@ -47,12 +47,18 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
       return { date, value: avg };
     });
   });
-  // intrinsic dimensions for viewBox calculations
-  const width = 600;
-  const height = 300;
-  const x = (score: number) => (score / 25) * width;
-  const y = (date: Date) =>
-    ((date.getTime() - start.getTime()) / (end.getTime() - start.getTime())) * height;
+  // dimensions and scales
+  const margin = { top: 20, right: 20, bottom: 60, left: 50 };
+  const innerHeight = 300;
+  const innerWidth = Math.max(600, dates.length * 100);
+  const width = innerWidth + margin.left + margin.right;
+  const height = innerHeight + margin.top + margin.bottom;
+  const x = (date: Date) =>
+    margin.left +
+    ((date.getTime() - start.getTime()) / (end.getTime() - start.getTime())) *
+      innerWidth;
+  const y = (score: number) =>
+    margin.top + innerHeight - (score / 25) * innerHeight;
   const colors = ['#ef4444', '#f59e0b', '#10b981', '#3b82f6'];
 
   return (
@@ -64,66 +70,101 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
         style={{ maxHeight: height }}
       >
         {/* axes */}
-        <line x1={0} y1={0} x2={0} y2={height} stroke="#000" />
-        <line x1={0} y1={height} x2={width} y2={height} stroke="#000" />
+        <line
+          x1={margin.left}
+          y1={margin.top}
+          x2={margin.left}
+          y2={margin.top + innerHeight}
+          stroke="#000"
+        />
+        <line
+          x1={margin.left}
+          y1={margin.top + innerHeight}
+          x2={margin.left + innerWidth}
+          y2={margin.top + innerHeight}
+          stroke="#000"
+        />
         {/* grid lines */}
         {dates.slice(1).map((d, i) => (
           <line
-            key={`h-${i}`}
-            x1={0}
-            y1={y(d)}
-            x2={width}
-            y2={y(d)}
+            key={`v-${i}`}
+            x1={x(d)}
+            y1={margin.top}
+            x2={x(d)}
+            y2={margin.top + innerHeight}
             stroke="#ddd"
           />
         ))}
         {[5, 10, 15, 20, 25].map((s) => (
           <line
-            key={`v-${s}`}
-            x1={x(s)}
-            y1={0}
-            x2={x(s)}
-            y2={height}
+            key={`h-${s}`}
+            x1={margin.left}
+            y1={y(s)}
+            x2={margin.left + innerWidth}
+            y2={y(s)}
             stroke="#ddd"
           />
         ))}
         {/* y-axis labels */}
-        {dates.map((d, i) => (
-          <g key={i}>
-            <line x1={0} y1={y(d)} x2={-5} y2={y(d)} stroke="#000" />
-            <text x={-8} y={y(d) + 4} textAnchor="end" fontSize="10">
-              {d.toISOString().split('T')[0]}
+        {[0, 5, 10, 15, 20, 25].map((s) => (
+          <g key={s}>
+            <line
+              x1={margin.left}
+              y1={y(s)}
+              x2={margin.left - 5}
+              y2={y(s)}
+              stroke="#000"
+            />
+            <text
+              x={margin.left - 8}
+              y={y(s) + 4}
+              textAnchor="end"
+              fontSize="10"
+            >
+              {s}
             </text>
           </g>
         ))}
         {/* x-axis labels */}
-        {[0, 5, 10, 15, 20, 25].map((s) => (
-          <g key={s}>
-            <line x1={x(s)} y1={height} x2={x(s)} y2={height + 5} stroke="#000" />
-            <text x={x(s)} y={height + 15} textAnchor="middle" fontSize="10">
-              {s}
+        {dates.map((d, i) => (
+          <g key={i}>
+            <line
+              x1={x(d)}
+              y1={margin.top + innerHeight}
+              x2={x(d)}
+              y2={margin.top + innerHeight + 5}
+              stroke="#000"
+            />
+            <text
+              x={x(d)}
+              y={margin.top + innerHeight + 15}
+              textAnchor="end"
+              fontSize="10"
+              transform={`rotate(-45 ${x(d)} ${margin.top + innerHeight + 15})`}
+            >
+              {d.toISOString().split('T')[0]}
             </text>
           </g>
         ))}
         {/* axis titles */}
         <text
-          x={width / 2}
-          y={height + 35}
+          x={margin.left + innerWidth / 2}
+          y={height - 10}
           textAnchor="middle"
           fontSize="12"
           fontWeight="bold"
-        >
-          Risk Score
-        </text>
-        <text
-          x={-40}
-          y={height / 2}
-          textAnchor="middle"
-          fontSize="12"
-          fontWeight="bold"
-          transform={`rotate(-90 -40 ${height / 2})`}
         >
           Date
+        </text>
+        <text
+          x={15}
+          y={margin.top + innerHeight / 2}
+          textAnchor="middle"
+          fontSize="12"
+          fontWeight="bold"
+          transform={`rotate(-90 15 ${margin.top + innerHeight / 2})`}
+        >
+          Risk Score
         </text>
         {series.map((data, idx) => (
           <polyline
@@ -131,7 +172,7 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
             fill="none"
             stroke={colors[idx]}
             strokeWidth={2}
-            points={data.map((p) => `${x(p.value)},${y(p.date)}`).join(' ')}
+            points={data.map((p) => `${x(p.date)},${y(p.value)}`).join(' ')}
           />
         ))}
       </svg>


### PR DESCRIPTION
## Summary
- allocate margins for axis labels
- rotate date labels for better spacing
- compute drawing area with margins

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c34c24b4c8325bc64d91426190b5f