### PR TITLE
Add project details panel and improve redirects

### DIFF
--- a/src/components/ProjectDetailsPanel.tsx
+++ b/src/components/ProjectDetailsPanel.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ProjectMeta } from '@/types/project';
+
+interface Props {
+  meta: ProjectMeta;
+}
+
+export default function ProjectDetailsPanel({ meta }: Props) {
+  return (
+    <div className="bg-white rounded-lg shadow p-4">
+      <h2 className="font-semibold mb-2">Project Details</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-sm">
+        <p>
+          <span className="font-medium">Name: </span>
+          {meta.projectName || 'Untitled Project'}
+        </p>
+        <p>
+          <span className="font-medium">Manager: </span>
+          {meta.projectManager || '-'}
+        </p>
+        <p>
+          <span className="font-medium">Sponsor: </span>
+          {meta.sponsor || '-'}
+        </p>
+        <p>
+          <span className="font-medium">Start: </span>
+          {meta.startDate || '-'}
+        </p>
+        <p>
+          <span className="font-medium">End: </span>
+          {meta.endDate || '-'}
+        </p>
+      </div>
+      {meta.riskPlan && (
+        <div className="mt-2 text-sm whitespace-pre-wrap">
+          <span className="font-medium">Risk Plan:</span> {meta.riskPlan}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -6,6 +6,7 @@ import { ProjectMeta, Project } from '@/types/project';
 import RiskHistoryTimeline from '@/components/RiskHistoryTimeline';
 import RiskMatrixPanel from '@/components/RiskMatrixPanel';
 import AggregatedRiskPanel from '@/components/AggregatedRiskPanel';
+import ProjectDetailsPanel from '@/components/ProjectDetailsPanel';
 import * as XLSX from 'xlsx';
 
 export default function ProjectHome() {
@@ -235,6 +236,7 @@ export default function ProjectHome() {
         </div>
       </nav>
       <main className="container mx-auto p-4 space-y-6">
+        <ProjectDetailsPanel meta={meta} />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="space-y-4">
             <AggregatedRiskPanel score={aggregatedScore} />

--- a/src/pages/project/[pid]/risk/index.tsx
+++ b/src/pages/project/[pid]/risk/index.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function RiskIndex() {
+  const router = useRouter();
+  const { pid } = router.query;
+
+  useEffect(() => {
+    if (pid) {
+      router.replace(`/project/${pid}`);
+    }
+  }, [router, pid]);
+
+  return <p className="p-4">Redirecting...</p>;
+}

--- a/src/pages/project/index.tsx
+++ b/src/pages/project/index.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function ProjectIndex() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/projects');
+  }, [router]);
+  return <p className="p-4">Redirecting...</p>;
+}


### PR DESCRIPTION
## Summary
- show project metadata on dashboard
- redirect `/project` to `/projects`
- add redirect for `/project/[pid]/risk` index

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c3b0a3cc883259518733b69bd91d9