### PR TITLE
Change dashboard grid to 30/70 split

### DIFF
--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -238,8 +238,8 @@ export default function ProjectHome() {
       </nav>
       <main className="container mx-auto p-4 space-y-6">
         <ProjectDetailsPanel meta={meta} />
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-10 gap-4">
+          <div className="space-y-4 md:col-span-3">
             <AggregatedRiskPanel score={aggregatedScore} />
             <RiskMatrixPanel
               matrix={matrix}
@@ -247,7 +247,7 @@ export default function ProjectHome() {
               onCellClick={handleCellClick}
             />
           </div>
-          <div className="bg-white rounded-lg shadow p-4">
+          <div className="bg-white rounded-lg shadow p-4 md:col-span-7">
             <h2 className="font-semibold mb-2">Risk History Timeline</h2>
             <RiskHistoryTimeline risks={risks} project={meta} />
           </div>


### PR DESCRIPTION
## Summary
- adjust project dashboard grid columns so Timeline has 70% width

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c3c242f048325ad57d1c4705e65f4