### PR TITLE
Update timeline metrics and layout

### DIFF
--- a/src/components/RiskHistoryTimeline.tsx
+++ b/src/components/RiskHistoryTimeline.tsx
@@ -40,13 +40,14 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
           new Date(r.dateIdentified) <= date &&
           r.status === status,
       );
-      const avg =
-        active.length === 0
-          ? 0
-          : active.reduce((s, r) => s + r.probability * r.impact, 0) / active.length;
-      return { date, value: avg };
+      return { date, value: active.length };
     });
   });
+
+  const maxCount = Math.max(
+    1,
+    ...series.flat().map((d) => d.value),
+  );
   // dimensions and scales
   const margin = { top: 20, right: 20, bottom: 60, left: 50 };
   const innerHeight = 300;
@@ -57,9 +58,15 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
     margin.left +
     ((date.getTime() - start.getTime()) / (end.getTime() - start.getTime())) *
       innerWidth;
-  const y = (score: number) =>
-    margin.top + innerHeight - (score / 25) * innerHeight;
+  const y = (count: number) =>
+    margin.top + innerHeight - (count / maxCount) * innerHeight;
   const colors = ['#ef4444', '#f59e0b', '#10b981', '#3b82f6'];
+  const tickStep = Math.max(1, Math.ceil(maxCount / 5));
+  const yTicks: number[] = [];
+  for (let i = 0; i <= maxCount; i += tickStep) {
+    yTicks.push(i);
+  }
+  if (yTicks[yTicks.length - 1] !== maxCount) yTicks.push(maxCount);
 
   return (
     <div className="overflow-auto">
@@ -95,7 +102,7 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
             stroke="#ddd"
           />
         ))}
-        {[5, 10, 15, 20, 25].map((s) => (
+        {yTicks.slice(1).map((s) => (
           <line
             key={`h-${s}`}
             x1={margin.left}
@@ -106,7 +113,7 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
           />
         ))}
         {/* y-axis labels */}
-        {[0, 5, 10, 15, 20, 25].map((s) => (
+        {yTicks.map((s) => (
           <g key={s}>
             <line
               x1={margin.left}
@@ -164,7 +171,7 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
           fontWeight="bold"
           transform={`rotate(-90 15 ${margin.top + innerHeight / 2})`}
         >
-          Risk Score
+          Number of Risks
         </text>
         {series.map((data, idx) => (
           <polyline

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -233,7 +233,7 @@ export default function ProjectHome() {
       <main className="container mx-auto p-4 space-y-6">
         <ProjectDetailsPanel meta={meta} pid={pid as string} />
         <div className="grid grid-cols-1 md:grid-cols-10 gap-4">
-          <div className="space-y-4 md:col-span-3">
+          <div className="space-y-4 md:col-span-4">
             <AggregatedRiskPanel score={aggregatedScore} />
             <RiskMatrixPanel
               matrix={matrix}
@@ -241,7 +241,7 @@ export default function ProjectHome() {
               onCellClick={handleCellClick}
             />
           </div>
-          <div className="bg-white rounded-lg shadow p-4 md:col-span-7">
+          <div className="bg-white rounded-lg shadow p-4 md:col-span-6">
             <h2 className="font-semibold mb-2">Risk History Timeline</h2>
             <RiskHistoryTimeline risks={risks} project={meta} />
           </div>


### PR DESCRIPTION
## Summary
- compute counts instead of risk scores in RiskHistoryTimeline
- adjust scaling and axis ticks for counts
- change y-axis label to "Number of Risks"
- switch project page layout from 30/70 to 40/60

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c3e15342483259a1fc483c75b416d