### PR TITLE
Improve project dashboard layout and dropdown

### DIFF
--- a/src/components/ProjectDetailsPanel.tsx
+++ b/src/components/ProjectDetailsPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ProjectMeta } from '@/types/project';
 
 import Link from 'next/link';
@@ -9,33 +9,54 @@ interface Props {
 }
 
 export default function ProjectDetailsPanel({ meta, pid }: Props) {
+  const [open, setOpen] = useState(true);
   return (
-    <div className="bg-white rounded-lg shadow p-4">
-      <div className="flex items-center justify-between mb-2">
+    <div className="bg-white rounded-lg shadow">
+      <div
+        className="flex items-center justify-between p-4 cursor-pointer select-none"
+        onClick={() => setOpen((p) => !p)}
+      >
         <h2 className="font-semibold">Project Details</h2>
-        {pid && (
-          <Link
-            href={`/project/${pid}/settings`}
-            aria-label="Edit project details"
-            className="text-gray-600 hover:text-black"
-          >
-            <svg
-              className="w-5 h-5"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
+        <div className="flex items-center space-x-2">
+          {pid && (
+            <Link
+              href={`/project/${pid}/settings`}
+              aria-label="Edit project details"
+              className="text-gray-600 hover:text-black"
+              onClick={(e) => e.stopPropagation()}
             >
-              <path d="M17.414 2.586a2 2 0 0 0-2.828 0l-8.5 8.5a1 1 0 0 0-.263.45l-1.5 4.5a1 1 0 0 0 1.263 1.263l4.5-1.5a1 1 0 0 0 .45-.263l8.5-8.5a2 2 0 0 0 0-2.828l-1.622-1.622ZM15 3l2 2-8.25 8.25-2.12.707.707-2.121L15 3Z" />
-            </svg>
-          </Link>
-        )}
+              <svg
+                className="w-5 h-5"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path d="M17.414 2.586a2 2 0 0 0-2.828 0l-8.5 8.5a1 1 0 0 0-.263.45l-1.5 4.5a1 1 0 0 0 1.263 1.263l4.5-1.5a1 1 0 0 0 .45-.263l8.5-8.5a2 2 0 0 0 0-2.828l-1.622-1.622ZM15 3l2 2-8.25 8.25-2.12.707.707-2.121L15 3Z" />
+              </svg>
+            </Link>
+          )}
+          <svg
+            className={`w-4 h-4 transform transition-transform ${open ? 'rotate-180' : ''}`}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.23 7.21a.75.75 0 011.06-.02L10 10.78l3.71-3.59a.75.75 0 111.04 1.08l-4.23 4.09a.75.75 0 01-1.04 0L5.25 8.27a.75.75 0 01-.02-1.06z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </div>
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-sm">
-        <p>
-          <span className="font-medium">Name: </span>
-          {meta.projectName || 'Untitled Project'}
-        </p>
-        <p>
+      {open && (
+        <div className="px-4 pb-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-sm">
+            <p>
+              <span className="font-medium">Name: </span>
+              {meta.projectName || 'Untitled Project'}
+            </p>
+            <p>
           <span className="font-medium">Manager: </span>
           {meta.projectManager || '-'}
         </p>
@@ -51,10 +72,12 @@ export default function ProjectDetailsPanel({ meta, pid }: Props) {
           <span className="font-medium">End: </span>
           {meta.endDate || '-'}
         </p>
-      </div>
-      {meta.riskPlan && (
-        <div className="mt-2 text-sm whitespace-pre-wrap">
-          <span className="font-medium">Risk Plan:</span> {meta.riskPlan}
+          </div>
+          {meta.riskPlan && (
+            <div className="mt-2 text-sm whitespace-pre-wrap">
+              <span className="font-medium">Risk Plan:</span> {meta.riskPlan}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/RiskHistoryTimeline.tsx
+++ b/src/components/RiskHistoryTimeline.tsx
@@ -72,7 +72,7 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
     <div className="overflow-auto">
       <svg
         viewBox={`0 0 ${width} ${height}`}
-        className="border w-full h-auto"
+        className="w-full h-auto"
         preserveAspectRatio="xMidYMid meet"
         style={{ maxHeight: height }}
       >

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -209,7 +209,7 @@ export default function ProjectHome() {
                 Add +
               </button>
               {showAddOptions && (
-                <div className="absolute right-0 mt-1 w-32 bg-white border rounded shadow z-10">
+                <div className="absolute right-0 mt-1 w-32 bg-white text-black border rounded shadow z-10">
                   <Link
                     href={`/project/${pid}/risk/new`}
                     className="block px-3 py-1 hover:bg-gray-100"
@@ -233,7 +233,7 @@ export default function ProjectHome() {
       <main className="container mx-auto p-4 space-y-6">
         <ProjectDetailsPanel meta={meta} pid={pid as string} />
         <div className="grid grid-cols-1 md:grid-cols-10 gap-4">
-          <div className="space-y-4 md:col-span-4">
+          <div className="space-y-4 md:col-span-3">
             <AggregatedRiskPanel score={aggregatedScore} />
             <RiskMatrixPanel
               matrix={matrix}
@@ -241,7 +241,7 @@ export default function ProjectHome() {
               onCellClick={handleCellClick}
             />
           </div>
-          <div className="bg-white rounded-lg shadow p-4 md:col-span-6">
+          <div className="bg-white rounded-lg shadow p-4 md:col-span-7">
             <h2 className="font-semibold mb-2">Risk History Timeline</h2>
             <RiskHistoryTimeline risks={risks} project={meta} />
           </div>


### PR DESCRIPTION
## Summary
- expand timeline area on project dashboard
- update dropdown menu styling
- make project details section collapsible
- remove border around risk history chart

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4105f5948325a175f05b843ca450