### PR TITLE
Fix project route redirect

### DIFF
--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -34,8 +34,12 @@ export default function ProjectHome() {
     if (current) {
       setRisks(current.risks || []);
       setMeta(current.meta);
+    } else if (list.length > 0) {
+      router.replace(`/project/${list[list.length - 1].id}`);
+    } else {
+      router.replace('/projects');
     }
-  }, [router.isReady, pid]);
+  }, [router.isReady, pid, router]);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {


### PR DESCRIPTION
## Summary
- when loading an unknown project id, redirect to the latest saved project instead of showing a 404

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c459b5d108325a6ed20f790dee042