### PR TITLE
Fix project route redirect

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { Project } from '@/types/project';
+
+export default function Custom404() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    const saved = typeof window !== 'undefined' && localStorage.getItem('projects');
+    const list: Project[] = saved ? JSON.parse(saved) : [];
+    if (list.length > 0) {
+      router.replace(`/project/${list[list.length - 1].id}`);
+    } else {
+      router.replace('/projects');
+    }
+  }, [router]);
+
+  return null;
+}

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -34,8 +34,12 @@ export default function ProjectHome() {
     if (current) {
       setRisks(current.risks || []);
       setMeta(current.meta);
+    } else if (list.length > 0) {
+      router.replace(`/project/${list[list.length - 1].id}`);
+    } else {
+      router.replace('/projects');
     }
-  }, [router.isReady, pid]);
+  }, [router.isReady, pid, router]);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {


### PR DESCRIPTION
## Summary
- when loading an unknown project id, redirect to the latest saved project instead of showing a 404
- redirect any 404 to the latest project dashboard or `/projects` if none exist

## Testing
- `npm run lint`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685c459b5d108325a6ed20f790dee042