### PR TITLE
Add editable risk categories

### DIFF
--- a/src/pages/project/[pid]/risk/[id].tsx
+++ b/src/pages/project/[pid]/risk/[id].tsx
@@ -21,6 +21,7 @@ export default function ManageRisk() {
   const { pid, id } = router.query as { pid?: string; id?: string };
 
   const [risks, setRisks] = useState<Risk[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
   const [form, setForm] = useState<RiskInput>(emptyForm);
   const [statusNote, setStatusNote] = useState('');
   const [errors, setErrors] = useState<Partial<Record<keyof RiskInput, string>>>({});
@@ -39,6 +40,7 @@ export default function ManageRisk() {
       return;
     }
     setRisks(proj.risks);
+    setCategories(proj.categories || []);
     if (id && id !== 'new') {
       const risk = proj.risks.find((r) => r.id === id);
       if (risk) {
@@ -154,12 +156,22 @@ export default function ManageRisk() {
         <label htmlFor="category" className="block text-sm font-medium">
           Category
         </label>
-        <input
+        <select
           id="category"
           className="border p-1 w-full"
           value={form.category}
           onChange={(e) => setForm({ ...form, category: e.target.value })}
-        />
+        >
+          <option value="">Select...</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+          {!categories.includes(form.category) && form.category && (
+            <option value={form.category}>{form.category}</option>
+          )}
+        </select>
         {errors.category && <p className="text-red-500 text-sm">{errors.category}</p>}
 
         <label htmlFor="owner" className="block text-sm font-medium">

--- a/src/pages/project/[pid]/settings.tsx
+++ b/src/pages/project/[pid]/settings.tsx
@@ -14,6 +14,8 @@ export default function Settings() {
     riskPlan: '',
   });
   const [errors, setErrors] = useState<Partial<Record<keyof ProjectMeta, string>>>({});
+  const [categories, setCategories] = useState<string[]>([]);
+  const [newCategory, setNewCategory] = useState('');
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -30,6 +32,7 @@ export default function Settings() {
           endDate: proj.meta.endDate || '',
           riskPlan: proj.meta.riskPlan || '',
         });
+        setCategories(proj.categories || []);
       }
     }
   }, [router.isReady, pid]);
@@ -54,8 +57,9 @@ export default function Settings() {
     const idx = projects.findIndex((p) => p.id === pid);
     if (idx >= 0) {
       projects[idx].meta = form;
+      projects[idx].categories = categories;
     } else {
-      projects.push({ id: pid as string, meta: form, risks: [] });
+      projects.push({ id: pid as string, meta: form, risks: [], categories });
     }
     localStorage.setItem('projects', JSON.stringify(projects));
     router.push(`/project/${pid}`);
@@ -129,6 +133,42 @@ export default function Settings() {
           value={form.riskPlan}
           onChange={(e) => setForm({ ...form, riskPlan: e.target.value })}
         />
+
+        <label className="block text-sm font-medium mt-4">Risk Categories</label>
+        <ul className="space-y-1">
+          {categories.map((cat, idx) => (
+            <li key={idx} className="flex items-center">
+              <span className="flex-1">{cat}</span>
+              <button
+                type="button"
+                onClick={() => setCategories(categories.filter((_, i) => i !== idx))}
+                className="text-red-600 ml-2"
+              >
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div className="flex items-center mt-1">
+          <input
+            className="border p-1 flex-1"
+            value={newCategory}
+            onChange={(e) => setNewCategory(e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              const trimmed = newCategory.trim();
+              if (trimmed && !categories.includes(trimmed)) {
+                setCategories([...categories, trimmed]);
+              }
+              setNewCategory('');
+            }}
+            className="ml-2 border px-2 py-1 rounded"
+          >
+            Add
+          </button>
+        </div>
 
         <div className="space-x-2 text-right pt-2">
           <button onClick={save} className="bg-indigo-600 text-white px-3 py-1 rounded">

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -34,6 +34,7 @@ export default function Projects() {
         riskPlan: '',
       },
       risks: [],
+      categories: [],
     };
     const updated = [...projects, newProject];
     setProjects(updated);

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -13,4 +13,5 @@ export interface Project {
   id: string;
   meta: ProjectMeta;
   risks: Risk[];
+  categories: string[];
 }


### PR DESCRIPTION
## Summary
- store risk categories on each project
- allow editing project categories in settings
- load project categories on risk form
- show categories as a select list when managing a risk

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c5b35065883258d4f5402a5d28b23