### PR TITLE
Fix risk timeline label

### DIFF
--- a/src/components/RiskHistoryTimeline.tsx
+++ b/src/components/RiskHistoryTimeline.tsx
@@ -161,7 +161,7 @@ export default function RiskHistoryTimeline({ risks, project }: Props) {
           fontSize="12"
           fontWeight="bold"
         >
-          Date
+          Risks
         </text>
         <text
           x={15}


### PR DESCRIPTION
## Summary
- rename the Risk History Timeline x-axis label to `Risks`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c5cb2e6408325b8e5bcb80aa1f828