### PR TITLE
Improve risk register row display

### DIFF
--- a/src/components/RiskRow.tsx
+++ b/src/components/RiskRow.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Link from 'next/link';
+import { Risk } from '@/types/risk';
+
+interface Props {
+  risk: Risk;
+  pid: string;
+  onDelete: (id: string) => void;
+}
+
+export default function RiskRow({ risk, pid, onDelete }: Props) {
+  const shortId = risk.id.length > 6 ? risk.id.slice(-6) : risk.id;
+  const score = risk.probability * risk.impact;
+  return (
+    <tr className="border-t hover:bg-gray-50 transition">
+      <td className="border p-1 text-xs text-gray-500">{shortId}</td>
+      <td className="border p-1">
+        <div className="font-medium">{risk.description}</div>
+        <div className="text-xs text-gray-500">
+          {risk.category} | Owner: {risk.owner}
+        </div>
+      </td>
+      <td className="border p-1 text-center">
+        <div className="font-semibold">
+          {risk.probability} &times; {risk.impact}
+        </div>
+        <div className="text-xs text-gray-500">Score: {score}</div>
+      </td>
+      <td className="border p-1 text-sm">
+        <div>{risk.status}</div>
+        <div className="text-xs text-gray-500">
+          {risk.dateIdentified ? risk.dateIdentified.split('T')[0] : ''}
+          {risk.dateResolved && (
+            <>
+              {' → '}
+              {risk.dateResolved.split('T')[0]}
+            </>
+          )}
+        </div>
+      </td>
+      <td className="border p-1 space-x-2 whitespace-nowrap">
+        <Link href={`/project/${pid}/risk/${risk.id}`} className="text-blue-600">
+          Manage
+        </Link>
+        <button onClick={() => onDelete(risk.id)} className="text-red-600">
+          Delete
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -7,6 +7,7 @@ import RiskHistoryTimeline from '@/components/RiskHistoryTimeline';
 import RiskMatrixPanel from '@/components/RiskMatrixPanel';
 import AggregatedRiskPanel from '@/components/AggregatedRiskPanel';
 import ProjectDetailsPanel from '@/components/ProjectDetailsPanel';
+import RiskRow from '@/components/RiskRow';
 import * as XLSX from 'xlsx';
 
 export default function ProjectHome() {
@@ -317,34 +318,15 @@ export default function ProjectHome() {
             <thead>
               <tr className="bg-gray-100">
                 <th className="border p-1">ID</th>
-                <th className="border p-1">Description</th>
-                <th className="border p-1">Category</th>
-                <th className="border p-1">Prob</th>
-                <th className="border p-1">Impact</th>
-                <th className="border p-1">Identified</th>
-                <th className="border p-1">Resolved</th>
+                <th className="border p-1">Risk</th>
+                <th className="border p-1">Score</th>
+                <th className="border p-1">Status / Dates</th>
                 <th className="border p-1">Actions</th>
               </tr>
             </thead>
             <tbody>
               {filteredRisks.map((r) => (
-                <tr key={r.id} className="border-t hover:bg-gray-50 transition">
-                  <td className="border p-1">{r.id}</td>
-                  <td className="border p-1">{r.description}</td>
-                  <td className="border p-1">{r.category}</td>
-                  <td className="border p-1">{r.probability}</td>
-                  <td className="border p-1">{r.impact}</td>
-                  <td className="border p-1">{r.dateIdentified ? r.dateIdentified.split('T')[0] : ''}</td>
-                  <td className="border p-1">{r.dateResolved ? r.dateResolved.split('T')[0] : ''}</td>
-                  <td className="border p-1 space-x-2">
-                    <Link href={`/project/${pid}/risk/${r.id}`} className="text-blue-600">
-                      Manage
-                    </Link>
-                    <button onClick={() => removeRisk(r.id)} className="text-red-600">
-                      Delete
-                    </button>
-                  </td>
-                </tr>
+                <RiskRow key={r.id} risk={r} pid={pid as string} onDelete={removeRisk} />
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
## Summary
- create `RiskRow` component to format risk details in a concise table row
- update project page to use the new component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c5e9aac248325856e60dd57bcdf86