### PR TITLE
Show risk criticality with color

### DIFF
--- a/src/components/RiskRow.tsx
+++ b/src/components/RiskRow.tsx
@@ -8,6 +8,12 @@ interface Props {
   onDelete: (id: string) => void;
 }
 
+const scoreColor = (score: number) => {
+  if (score >= 15) return 'bg-red-500 text-white';
+  if (score >= 5) return 'bg-yellow-300';
+  return 'bg-green-300';
+};
+
 export default function RiskRow({ risk, pid, onDelete }: Props) {
   const shortId = risk.id.length > 6 ? risk.id.slice(-6) : risk.id;
   const score = risk.probability * risk.impact;
@@ -20,11 +26,17 @@ export default function RiskRow({ risk, pid, onDelete }: Props) {
           {risk.category} | Owner: {risk.owner}
         </div>
       </td>
-      <td className="border p-1 text-center">
-        <div className="font-semibold">
+      <td className="border p-1 text-center space-y-1">
+        <div
+          className={`w-8 h-8 mx-auto rounded-full flex items-center justify-center font-semibold ${scoreColor(
+            score
+          )}`}
+        >
+          {score}
+        </div>
+        <div className="text-xs text-gray-500">
           {risk.probability} &times; {risk.impact}
         </div>
-        <div className="text-xs text-gray-500">Score: {score}</div>
       </td>
       <td className="border p-1 text-sm">
         <div>{risk.status}</div>

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -319,7 +319,7 @@ export default function ProjectHome() {
               <tr className="bg-gray-100">
                 <th className="border p-1">ID</th>
                 <th className="border p-1">Risk</th>
-                <th className="border p-1">Score</th>
+                <th className="border p-1">Criticality</th>
                 <th className="border p-1">Status / Dates</th>
                 <th className="border p-1">Actions</th>
               </tr>


### PR DESCRIPTION
## Summary
- color-code risk scores using red/yellow/green circles
- rename score column to **Criticality**

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c61844190832593ba33e272412ecf