### PR TITLE
Remove formula text in criticality column

### DIFF
--- a/src/components/RiskRow.tsx
+++ b/src/components/RiskRow.tsx
@@ -34,9 +34,6 @@ export default function RiskRow({ risk, pid, onDelete }: Props) {
         >
           {score}
         </div>
-        <div className="text-xs text-gray-500">
-          {risk.probability} &times; {risk.impact}
-        </div>
       </td>
       <td className="border p-1 text-sm">
         <div>{risk.status}</div>


### PR DESCRIPTION
## Summary
- remove probability × impact text from the Criticality column

## Testing
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_685c62eb80cc8325941eaedf84048cb1