### PR TITLE
Add priority to risks

### DIFF
--- a/data/risks.json
+++ b/data/risks.json
@@ -8,6 +8,7 @@
     "impact": 3,
     "owner": "joe",
     "mitigation": "action plan",
+    "priority": "Medium",
     "status": "In-Progress",
     "response": "Mitigate",
     "statusHistory": [
@@ -29,6 +30,7 @@
     "impact": 1,
     "owner": "",
     "mitigation": "",
+    "priority": "Medium",
     "status": "Open",
     "response": "Accept",
     "statusHistory": [
@@ -50,6 +52,7 @@
     "impact": 1,
     "owner": "",
     "mitigation": "",
+    "priority": "Medium",
     "status": "Open",
     "response": "Transfer",
     "statusHistory": [

--- a/src/components/RiskRow.tsx
+++ b/src/components/RiskRow.tsx
@@ -35,6 +35,7 @@ export default function RiskRow({ risk, pid, onDelete }: Props) {
           {score}
         </div>
       </td>
+      <td className="border p-1 text-center">{risk.priority}</td>
       <td className="border p-1 text-sm">
         <div>{risk.status}</div>
         <div className="text-xs text-gray-500">

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -189,6 +189,7 @@ export default function ProjectHome() {
           impact: Number(r['impact']) || 1,
           owner: (r['owner'] as string) || '',
           mitigation: (r['mitigation'] as string) || '',
+          priority: (r['priority'] as Risk['priority']) || 'Medium',
           response: (r['response'] as Risk['response']) || 'Mitigate',
           status: (r['status'] as Risk['status']) || 'Open',
           statusHistory: [],
@@ -358,6 +359,7 @@ export default function ProjectHome() {
                     )}
                   </div>
                 </th>
+                <th className="border p-1">Priority</th>
                 <th className="border p-1">Status / Dates</th>
                 <th className="border p-1">Actions</th>
               </tr>

--- a/src/pages/project/[pid]/risk/[id].tsx
+++ b/src/pages/project/[pid]/risk/[id].tsx
@@ -10,6 +10,7 @@ const emptyForm: RiskInput = {
   impact: 1,
   owner: '',
   mitigation: '',
+  priority: 'Medium',
   response: 'Mitigate',
   status: 'Open',
   dateIdentified: new Date().toISOString(),
@@ -83,6 +84,7 @@ export default function ManageRisk() {
     if (!form.category.trim()) errs.category = 'Category is required';
     if (!form.owner.trim()) errs.owner = 'Owner is required';
     if (!form.mitigation.trim()) errs.mitigation = 'Mitigation is required';
+    if (!form.priority) errs.priority = 'Priority is required';
     if (!form.response) errs.response = 'Response is required';
     if (form.probability < 1 || form.probability > 5) errs.probability = 'Probability must be 1-5';
     if (form.impact < 1 || form.impact > 5) errs.impact = 'Impact must be 1-5';
@@ -195,6 +197,23 @@ export default function ManageRisk() {
           onChange={(e) => setForm({ ...form, mitigation: e.target.value })}
         />
         {errors.mitigation && <p className="text-red-500 text-sm">{errors.mitigation}</p>}
+
+        <label htmlFor="priority" className="block text-sm font-medium">
+          Priority
+        </label>
+        <select
+          id="priority"
+          className="border p-1 w-full"
+          value={form.priority}
+          onChange={(e) =>
+            setForm({ ...form, priority: e.target.value as Risk['priority'] })
+          }
+        >
+          <option>High</option>
+          <option>Medium</option>
+          <option>Low</option>
+        </select>
+        {errors.priority && <p className="text-red-500 text-sm">{errors.priority}</p>}
 
         <label htmlFor="response" className="block text-sm font-medium">
           Response

--- a/src/types/risk.ts
+++ b/src/types/risk.ts
@@ -14,6 +14,7 @@ export interface Risk {
   impact: number; // 1-5
   owner: string;
   mitigation: string;
+  priority: 'High' | 'Medium' | 'Low';
   status: RiskStatus;
   response: 'Avoid' | 'Mitigate' | 'Transfer' | 'Accept';
   statusHistory: StatusChange[];


### PR DESCRIPTION
## Summary
- add `priority` property to risk type
- include priority in risk form with validation
- show priority column in risk register table
- update sample data with priority
- fix import mapping for risk priority

## Testing
- `npm install`
- `npm run lint`
- `npx --no-install next build`


------
https://chatgpt.com/codex/tasks/task_e_685c6e9291b083259aacd1db245c9177