### PR TITLE
Improve forms layout

### DIFF
--- a/src/pages/project/[pid]/risk/[id].tsx
+++ b/src/pages/project/[pid]/risk/[id].tsx
@@ -143,164 +143,197 @@ export default function ManageRisk() {
   return (
     <div className="min-h-screen bg-gray-50 p-4">
       <h1 className="text-xl font-semibold mb-4">{id === 'new' ? 'Add Risk' : 'Edit Risk'}</h1>
-      <div className="bg-white rounded-lg shadow p-4 space-y-2 max-w-xl mx-auto">
-        <label htmlFor="description" className="block text-sm font-medium">
-          Description
-        </label>
-        <input
-          id="description"
-          className="border p-1 w-full"
-          value={form.description}
-          onChange={(e) => setForm({ ...form, description: e.target.value })}
-        />
-        {errors.description && <p className="text-red-500 text-sm">{errors.description}</p>}
-
-        <label htmlFor="category" className="block text-sm font-medium">
-          Category
-        </label>
-        <select
-          id="category"
-          className="border p-1 w-full"
-          value={form.category}
-          onChange={(e) => setForm({ ...form, category: e.target.value })}
-        >
-          <option value="">Select...</option>
-          {categories.map((c) => (
-            <option key={c} value={c}>
-              {c}
-            </option>
-          ))}
-          {!categories.includes(form.category) && form.category && (
-            <option value={form.category}>{form.category}</option>
-          )}
-        </select>
-        {errors.category && <p className="text-red-500 text-sm">{errors.category}</p>}
-
-        <label htmlFor="owner" className="block text-sm font-medium">
-          Owner
-        </label>
-        <input
-          id="owner"
-          className="border p-1 w-full"
-          value={form.owner}
-          onChange={(e) => setForm({ ...form, owner: e.target.value })}
-        />
-        {errors.owner && <p className="text-red-500 text-sm">{errors.owner}</p>}
-
-        <label htmlFor="mitigation" className="block text-sm font-medium">
-          Mitigation
-        </label>
-        <textarea
-          id="mitigation"
-          className="border p-1 w-full"
-          value={form.mitigation}
-          onChange={(e) => setForm({ ...form, mitigation: e.target.value })}
-        />
-        {errors.mitigation && <p className="text-red-500 text-sm">{errors.mitigation}</p>}
-
-        <label htmlFor="priority" className="block text-sm font-medium">
-          Priority
-        </label>
-        <select
-          id="priority"
-          className="border p-1 w-full"
-          value={form.priority}
-          onChange={(e) =>
-            setForm({ ...form, priority: e.target.value as Risk['priority'] })
-          }
-        >
-          <option>High</option>
-          <option>Medium</option>
-          <option>Low</option>
-        </select>
-        {errors.priority && <p className="text-red-500 text-sm">{errors.priority}</p>}
-
-        <label htmlFor="response" className="block text-sm font-medium">
-          Response
-        </label>
-        <select
-          id="response"
-          className="border p-1 w-full"
-          value={form.response}
-          onChange={(e) => setForm({ ...form, response: e.target.value as Risk['response'] })}
-        >
-          <option>Avoid</option>
-          <option>Mitigate</option>
-          <option>Transfer</option>
-          <option>Accept</option>
-        </select>
-        {errors.response && <p className="text-red-500 text-sm">{errors.response}</p>}
-
-        <label htmlFor="status" className="block text-sm font-medium">
-          Status
-        </label>
-        <select
-          id="status"
-          className="border p-1 w-full"
-          value={form.status}
-          onChange={(e) => setForm({ ...form, status: e.target.value as Risk['status'] })}
-        >
-          <option>Open</option>
-          <option>In-Progress</option>
-          <option>Mitigated</option>
-          <option>Accepted</option>
-        </select>
-
-        <label htmlFor="statusNote" className="block text-sm font-medium">
-          Status Change Note
-        </label>
-        <textarea
-          id="statusNote"
-          className="border p-1 w-full"
-          value={statusNote}
-          onChange={(e) => setStatusNote(e.target.value)}
-        />
-
-        <label htmlFor="dateIdentified" className="block text-sm font-medium">
-          Date Identified
-        </label>
-        <input
-          id="dateIdentified"
-          type="date"
-          className="border p-1 w-full"
-          value={form.dateIdentified ? form.dateIdentified.split('T')[0] : ''}
-          onChange={(e) => setForm({ ...form, dateIdentified: e.target.value })}
-        />
-        {errors.dateIdentified && <p className="text-red-500 text-sm">{errors.dateIdentified}</p>}
-
-        <label htmlFor="dateResolved" className="block text-sm font-medium">
-          Date Resolved
-        </label>
-        <input
-          id="dateResolved"
-          type="date"
-          className="border p-1 w-full"
-          value={form.dateResolved ? form.dateResolved.split('T')[0] : ''}
-          onChange={(e) => setForm({ ...form, dateResolved: e.target.value })}
-        />
-        {errors.dateResolved && <p className="text-red-500 text-sm">{errors.dateResolved}</p>}
-
-        <div className="flex gap-2">
-          <label htmlFor="probability">Prob</label>
+      <div className="bg-white rounded-lg shadow p-4 space-y-6 max-w-3xl mx-auto">
+        <div className="space-y-1">
+          <label htmlFor="description" className="block text-sm font-medium">
+            Description
+          </label>
           <input
-            id="probability"
-            type="number"
-            min="1"
-            max="5"
-            className="border"
-            value={form.probability}
-            onChange={(e) => setForm({ ...form, probability: Number(e.target.value) })}
+            id="description"
+            className="border p-1 w-full"
+            value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
           />
-          <label htmlFor="impact">Impact</label>
-          <input
-            id="impact"
-            type="number"
-            min="1"
-            max="5"
-            className="border"
-            value={form.impact}
-            onChange={(e) => setForm({ ...form, impact: Number(e.target.value) })}
+          {errors.description && <p className="text-red-500 text-sm">{errors.description}</p>}
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label htmlFor="category" className="block text-sm font-medium">
+              Category
+            </label>
+            <select
+              id="category"
+              className="border p-1 w-full"
+              value={form.category}
+              onChange={(e) => setForm({ ...form, category: e.target.value })}
+            >
+              <option value="">Select...</option>
+              {categories.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+              {!categories.includes(form.category) && form.category && (
+                <option value={form.category}>{form.category}</option>
+              )}
+            </select>
+            {errors.category && <p className="text-red-500 text-sm">{errors.category}</p>}
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="owner" className="block text-sm font-medium">
+              Owner
+            </label>
+            <input
+              id="owner"
+              className="border p-1 w-full"
+              value={form.owner}
+              onChange={(e) => setForm({ ...form, owner: e.target.value })}
+            />
+            {errors.owner && <p className="text-red-500 text-sm">{errors.owner}</p>}
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="mitigation" className="block text-sm font-medium">
+            Mitigation
+          </label>
+          <textarea
+            id="mitigation"
+            className="border p-1 w-full"
+            value={form.mitigation}
+            onChange={(e) => setForm({ ...form, mitigation: e.target.value })}
           />
+          {errors.mitigation && <p className="text-red-500 text-sm">{errors.mitigation}</p>}
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label htmlFor="priority" className="block text-sm font-medium">
+              Priority
+            </label>
+            <select
+              id="priority"
+              className="border p-1 w-full"
+              value={form.priority}
+              onChange={(e) =>
+                setForm({ ...form, priority: e.target.value as Risk['priority'] })
+              }
+            >
+              <option>High</option>
+              <option>Medium</option>
+              <option>Low</option>
+            </select>
+            {errors.priority && <p className="text-red-500 text-sm">{errors.priority}</p>}
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="response" className="block text-sm font-medium">
+              Response
+            </label>
+            <select
+              id="response"
+              className="border p-1 w-full"
+              value={form.response}
+              onChange={(e) => setForm({ ...form, response: e.target.value as Risk['response'] })}
+            >
+              <option>Avoid</option>
+              <option>Mitigate</option>
+              <option>Transfer</option>
+              <option>Accept</option>
+            </select>
+            {errors.response && <p className="text-red-500 text-sm">{errors.response}</p>}
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label htmlFor="status" className="block text-sm font-medium">
+              Status
+            </label>
+            <select
+              id="status"
+              className="border p-1 w-full"
+              value={form.status}
+              onChange={(e) => setForm({ ...form, status: e.target.value as Risk['status'] })}
+            >
+              <option>Open</option>
+              <option>In-Progress</option>
+              <option>Mitigated</option>
+              <option>Accepted</option>
+            </select>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="statusNote" className="block text-sm font-medium">
+              Status Change Note
+            </label>
+            <textarea
+              id="statusNote"
+              className="border p-1 w-full"
+              value={statusNote}
+              onChange={(e) => setStatusNote(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label htmlFor="dateIdentified" className="block text-sm font-medium">
+              Date Identified
+            </label>
+            <input
+              id="dateIdentified"
+              type="date"
+              className="border p-1 w-full"
+              value={form.dateIdentified ? form.dateIdentified.split('T')[0] : ''}
+              onChange={(e) => setForm({ ...form, dateIdentified: e.target.value })}
+            />
+            {errors.dateIdentified && <p className="text-red-500 text-sm">{errors.dateIdentified}</p>}
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="dateResolved" className="block text-sm font-medium">
+              Date Resolved
+            </label>
+            <input
+              id="dateResolved"
+              type="date"
+              className="border p-1 w-full"
+              value={form.dateResolved ? form.dateResolved.split('T')[0] : ''}
+              onChange={(e) => setForm({ ...form, dateResolved: e.target.value })}
+            />
+            {errors.dateResolved && <p className="text-red-500 text-sm">{errors.dateResolved}</p>}
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label htmlFor="probability">Probability (1 low, 5 high)</label>
+            <input
+              id="probability"
+              type="number"
+              min="1"
+              max="5"
+              className="border w-full"
+              value={form.probability}
+              onChange={(e) => setForm({ ...form, probability: Number(e.target.value) })}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="impact">Impact (1 low, 5 high)</label>
+            <input
+              id="impact"
+              type="number"
+              min="1"
+              max="5"
+              className="border w-full"
+              value={form.impact}
+              onChange={(e) => setForm({ ...form, impact: Number(e.target.value) })}
+            />
+          </div>
         </div>
         {errors.probability && <p className="text-red-500 text-sm">{errors.probability}</p>}
         {errors.impact && <p className="text-red-500 text-sm">{errors.impact}</p>}

--- a/src/pages/project/[pid]/settings.tsx
+++ b/src/pages/project/[pid]/settings.tsx
@@ -68,106 +68,126 @@ export default function Settings() {
   return (
     <div className="min-h-screen bg-gray-50 p-4">
       <h1 className="text-xl font-semibold mb-4">Project Details</h1>
-      <div className="bg-white rounded-lg shadow p-4 space-y-3 max-w-xl mx-auto">
-        <label htmlFor="projectName" className="block text-sm font-medium">
-          Project Name
-        </label>
-        <input
-          id="projectName"
-          className="border p-2 rounded w-full"
-          value={form.projectName}
-          onChange={(e) => setForm({ ...form, projectName: e.target.value })}
-        />
-        {errors.projectName && <p className="text-red-500 text-sm">{errors.projectName}</p>}
+      <div className="bg-white rounded-lg shadow p-4 space-y-6 max-w-3xl mx-auto">
+        <p className="text-sm text-gray-500">Fill in basic project information and risk setup.</p>
 
-        <label htmlFor="projectManager" className="block text-sm font-medium">
-          Project Manager
-        </label>
-        <input
-          id="projectManager"
-          className="border p-2 rounded w-full"
-          value={form.projectManager}
-          onChange={(e) => setForm({ ...form, projectManager: e.target.value })}
-        />
+        <div className="grid md:grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label htmlFor="projectName" className="block text-sm font-medium">
+              Project Name
+            </label>
+            <input
+              id="projectName"
+              className="border p-2 rounded w-full"
+              value={form.projectName}
+              onChange={(e) => setForm({ ...form, projectName: e.target.value })}
+            />
+            {errors.projectName && <p className="text-red-500 text-sm">{errors.projectName}</p>}
+          </div>
 
-        <label htmlFor="sponsor" className="block text-sm font-medium">
-          Sponsor
-        </label>
-        <input
-          id="sponsor"
-          className="border p-2 rounded w-full"
-          value={form.sponsor}
-          onChange={(e) => setForm({ ...form, sponsor: e.target.value })}
-        />
+          <div className="space-y-1">
+            <label htmlFor="projectManager" className="block text-sm font-medium">
+              Project Manager
+            </label>
+            <input
+              id="projectManager"
+              className="border p-2 rounded w-full"
+              value={form.projectManager}
+              onChange={(e) => setForm({ ...form, projectManager: e.target.value })}
+            />
+          </div>
 
-        <label htmlFor="startDate" className="block text-sm font-medium">
-          Start Date
-        </label>
-        <input
-          id="startDate"
-          type="date"
-          className="border p-2 rounded w-full"
-          value={form.startDate}
-          onChange={(e) => setForm({ ...form, startDate: e.target.value })}
-        />
-        {errors.startDate && <p className="text-red-500 text-sm">{errors.startDate}</p>}
+          <div className="space-y-1">
+            <label htmlFor="sponsor" className="block text-sm font-medium">
+              Sponsor
+            </label>
+            <input
+              id="sponsor"
+              className="border p-2 rounded w-full"
+              value={form.sponsor}
+              onChange={(e) => setForm({ ...form, sponsor: e.target.value })}
+            />
+          </div>
 
-        <label htmlFor="endDate" className="block text-sm font-medium">
-          End Date
-        </label>
-        <input
-          id="endDate"
-          type="date"
-          className="border p-2 rounded w-full"
-          value={form.endDate}
-          onChange={(e) => setForm({ ...form, endDate: e.target.value })}
-        />
-        {errors.endDate && <p className="text-red-500 text-sm">{errors.endDate}</p>}
+          <div className="space-y-1">
+            <label htmlFor="startDate" className="block text-sm font-medium">
+              Start Date
+            </label>
+            <input
+              id="startDate"
+              type="date"
+              className="border p-2 rounded w-full"
+              value={form.startDate}
+              onChange={(e) => setForm({ ...form, startDate: e.target.value })}
+            />
+            {errors.startDate && <p className="text-red-500 text-sm">{errors.startDate}</p>}
+          </div>
 
-        <label htmlFor="riskPlan" className="block text-sm font-medium">
-          Risk Management Plan
-        </label>
-        <textarea
-          id="riskPlan"
-          className="border p-2 rounded w-full"
-          value={form.riskPlan}
-          onChange={(e) => setForm({ ...form, riskPlan: e.target.value })}
-        />
+          <div className="space-y-1">
+            <label htmlFor="endDate" className="block text-sm font-medium">
+              End Date
+            </label>
+            <input
+              id="endDate"
+              type="date"
+              className="border p-2 rounded w-full"
+              value={form.endDate}
+              onChange={(e) => setForm({ ...form, endDate: e.target.value })}
+            />
+            {errors.endDate && <p className="text-red-500 text-sm">{errors.endDate}</p>}
+          </div>
+        </div>
 
-        <label className="block text-sm font-medium mt-4">Risk Categories</label>
-        <ul className="space-y-1">
-          {categories.map((cat, idx) => (
-            <li key={idx} className="flex items-center">
-              <span className="flex-1">{cat}</span>
-              <button
-                type="button"
-                onClick={() => setCategories(categories.filter((_, i) => i !== idx))}
-                className="text-red-600 ml-2"
-              >
-                Delete
-              </button>
-            </li>
-          ))}
-        </ul>
-        <div className="flex items-center mt-1">
-          <input
-            className="border p-1 flex-1"
-            value={newCategory}
-            onChange={(e) => setNewCategory(e.target.value)}
+        <div className="space-y-1">
+          <label htmlFor="riskPlan" className="block text-sm font-medium">
+            Risk Management Plan
+          </label>
+          <textarea
+            id="riskPlan"
+            className="border p-2 rounded w-full"
+            value={form.riskPlan}
+            onChange={(e) => setForm({ ...form, riskPlan: e.target.value })}
           />
-          <button
-            type="button"
-            onClick={() => {
-              const trimmed = newCategory.trim();
-              if (trimmed && !categories.includes(trimmed)) {
-                setCategories([...categories, trimmed]);
-              }
-              setNewCategory('');
-            }}
-            className="ml-2 border px-2 py-1 rounded"
-          >
-            Add
-          </button>
+          <p className="text-sm text-gray-500">Outline how risks will be managed throughout the project.</p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Risk Categories</label>
+          <p className="text-sm text-gray-500 mb-2">Add categories to classify project risks.</p>
+          <ul className="space-y-1 mb-2">
+            {categories.map((cat, idx) => (
+              <li key={idx} className="flex items-center">
+                <span className="flex-1">{cat}</span>
+                <button
+                  type="button"
+                  onClick={() => setCategories(categories.filter((_, i) => i !== idx))}
+                  className="text-red-600 ml-2"
+                >
+                  Delete
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="flex items-center">
+            <input
+              className="border p-1 flex-1"
+              value={newCategory}
+              onChange={(e) => setNewCategory(e.target.value)}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                const trimmed = newCategory.trim();
+                if (trimmed && !categories.includes(trimmed)) {
+                  setCategories([...categories, trimmed]);
+                }
+                setNewCategory('');
+              }}
+              className="ml-2 border px-2 py-1 rounded"
+            >
+              Add
+            </button>
+          </div>
         </div>
 
         <div className="space-x-2 text-right pt-2">


### PR DESCRIPTION
## Summary
- enhance project settings with grouped grid layout and instructions
- restructure risk editing UI with clearer sections and column layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d284a35dc8325877ad69dbefc3ba7