### PR TITLE
Add title to risk data

### DIFF
--- a/data/risks.json
+++ b/data/risks.json
@@ -2,6 +2,7 @@
   {
     "id": "1750787227213",
     "lastReviewed": "2025-06-24T17:47:07.213Z",
+    "title": "Example Risk",
     "description": "Something",
     "category": "tech",
     "probability": 3,
@@ -24,6 +25,7 @@
   {
     "id": "1750787259747",
     "lastReviewed": "2025-06-24T17:47:39.747Z",
+    "title": "",
     "description": "",
     "category": "",
     "probability": 1,
@@ -46,6 +48,7 @@
   {
     "id": "1750787260239",
     "lastReviewed": "2025-06-24T17:47:40.239Z",
+    "title": "",
     "description": "",
     "category": "",
     "probability": 1,

--- a/public/risks.json
+++ b/public/risks.json
@@ -2,6 +2,7 @@
   {
     "id": "1750787227213",
     "lastReviewed": "2025-06-24T17:47:07.213Z",
+    "title": "Example Risk",
     "description": "Something",
     "category": "tech",
     "probability": 3,
@@ -15,6 +16,7 @@
   {
     "id": "1750787259747",
     "lastReviewed": "2025-06-24T17:47:39.747Z",
+    "title": "",
     "description": "",
     "category": "",
     "probability": 1,
@@ -28,6 +30,7 @@
   {
     "id": "1750787260239",
     "lastReviewed": "2025-06-24T17:47:40.239Z",
+    "title": "",
     "description": "",
     "category": "",
     "probability": 1,

--- a/src/components/RiskRow.tsx
+++ b/src/components/RiskRow.tsx
@@ -21,7 +21,8 @@ export default function RiskRow({ risk, pid, onDelete }: Props) {
     <tr className="border-t hover:bg-gray-50 transition">
       <td className="border p-1 text-xs text-gray-500">{shortId}</td>
       <td className="border p-1">
-        <div className="font-medium">{risk.description}</div>
+        <div className="font-medium">{risk.title}</div>
+        <div className="text-xs text-gray-500">{risk.description}</div>
         <div className="text-xs text-gray-500">
           {risk.category} | Owner: {risk.owner}
         </div>

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -183,6 +183,7 @@ export default function ProjectHome() {
         const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(riskSheet);
         const records: Risk[] = rows.map((r) => ({
           id: (r['id'] as string) || Date.now().toString() + Math.random().toString(16).slice(2),
+          title: (r['title'] as string) || '',
           description: (r['description'] as string) || '',
           category: (r['category'] as string) || '',
           probability: Number(r['probability']) || 1,

--- a/src/pages/project/[pid]/risk/[id].tsx
+++ b/src/pages/project/[pid]/risk/[id].tsx
@@ -4,6 +4,7 @@ import { Risk, RiskInput } from '@/types/risk';
 import { Project } from '@/types/project';
 
 const emptyForm: RiskInput = {
+  title: '',
   description: '',
   category: '',
   probability: 1,
@@ -80,6 +81,7 @@ export default function ManageRisk() {
 
   const validate = () => {
     const errs: Partial<Record<keyof RiskInput, string>> = {};
+    if (!form.title.trim()) errs.title = 'Title is required';
     if (!form.description.trim()) errs.description = 'Description is required';
     if (!form.category.trim()) errs.category = 'Category is required';
     if (!form.owner.trim()) errs.owner = 'Owner is required';
@@ -144,6 +146,18 @@ export default function ManageRisk() {
     <div className="min-h-screen bg-gray-50 p-4">
       <h1 className="text-xl font-semibold mb-4">{id === 'new' ? 'Add Risk' : 'Edit Risk'}</h1>
       <div className="bg-white rounded-lg shadow p-4 space-y-6 max-w-3xl mx-auto">
+        <div className="space-y-1">
+          <label htmlFor="title" className="block text-sm font-medium">
+            Title
+          </label>
+          <input
+            id="title"
+            className="border p-1 w-full"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+          />
+          {errors.title && <p className="text-red-500 text-sm">{errors.title}</p>}
+        </div>
         <div className="space-y-1">
           <label htmlFor="description" className="block text-sm font-medium">
             Description

--- a/src/types/risk.ts
+++ b/src/types/risk.ts
@@ -8,6 +8,7 @@ export interface StatusChange {
 
 export interface Risk {
   id: string;
+  title: string;
   description: string;
   category: string;
   probability: number; // 1-5


### PR DESCRIPTION
## Summary
- support `title` in risk type
- update risk input form and validation
- render titles in risk list
- handle titles when importing from spreadsheets
- update sample data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d2ab406e083258c7acfe273817b33