### PR TITLE
Add consistent nav to forms

### DIFF
--- a/src/pages/project/[pid]/risk/[id].tsx
+++ b/src/pages/project/[pid]/risk/[id].tsx
@@ -141,9 +141,15 @@ export default function ManageRisk() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 p-4">
-      <h1 className="text-xl font-semibold mb-4">{id === 'new' ? 'Add Risk' : 'Edit Risk'}</h1>
-      <div className="bg-white rounded-lg shadow p-4 space-y-6 max-w-3xl mx-auto">
+    <div className="min-h-screen bg-gray-50">
+      <nav className="bg-blue-950 text-white shadow">
+        <div className="container mx-auto px-4 py-3 flex items-center">
+          <h1 className="text-xl font-semibold">Risk Manager</h1>
+        </div>
+      </nav>
+      <main className="container mx-auto p-4">
+        <h1 className="text-xl font-semibold mb-4">{id === 'new' ? 'Add Risk' : 'Edit Risk'}</h1>
+        <div className="bg-white rounded-lg shadow p-4 space-y-6 max-w-3xl mx-auto">
         <div className="space-y-1">
           <label htmlFor="description" className="block text-sm font-medium">
             Description
@@ -355,6 +361,7 @@ export default function ManageRisk() {
           </button>
         </div>
       </div>
+      </main>
     </div>
   );
 }

--- a/src/pages/project/[pid]/settings.tsx
+++ b/src/pages/project/[pid]/settings.tsx
@@ -66,9 +66,15 @@ export default function Settings() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 p-4">
-      <h1 className="text-xl font-semibold mb-4">Project Details</h1>
-      <div className="bg-white rounded-lg shadow p-4 space-y-6 max-w-3xl mx-auto">
+    <div className="min-h-screen bg-gray-50">
+      <nav className="bg-blue-950 text-white shadow">
+        <div className="container mx-auto px-4 py-3 flex items-center">
+          <h1 className="text-xl font-semibold">Risk Manager</h1>
+        </div>
+      </nav>
+      <main className="container mx-auto p-4">
+        <h1 className="text-xl font-semibold mb-4">Project Details</h1>
+        <div className="bg-white rounded-lg shadow p-4 space-y-6 max-w-3xl mx-auto">
         <p className="text-sm text-gray-500">Fill in basic project information and risk setup.</p>
 
         <div className="grid md:grid-cols-2 gap-4">
@@ -199,6 +205,7 @@ export default function Settings() {
           </button>
         </div>
       </div>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add navigation bar on risk and settings forms
- maintain the index page style but omit the Add+ button

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d2b70e5d883258962b3e39d989c1f