### PR TITLE
Fix status notes and adjust risk table

### DIFF
--- a/src/components/RiskRow.tsx
+++ b/src/components/RiskRow.tsx
@@ -15,25 +15,22 @@ const scoreColor = (score: number) => {
 };
 
 export default function RiskRow({ risk, pid, onDelete }: Props) {
-  const shortId = risk.id.length > 6 ? risk.id.slice(-6) : risk.id;
   const score = risk.probability * risk.impact;
+  const lastNote = risk.statusHistory[risk.statusHistory.length - 1]?.note || '';
   return (
     <tr className="border-t hover:bg-gray-50 transition">
-      <td className="border p-1 text-xs text-gray-500">{shortId}</td>
+      <td className="border p-1 text-center space-y-1">
+        <div
+          className={`w-8 h-8 mx-auto rounded-full flex items-center justify-center font-semibold ${scoreColor(score)}`}
+        >
+          {score}
+        </div>
+      </td>
       <td className="border p-1">
         <div className="font-medium">{risk.title}</div>
         <div className="text-xs text-gray-500">{risk.description}</div>
         <div className="text-xs text-gray-500">
           {risk.category} | Owner: {risk.owner}
-        </div>
-      </td>
-      <td className="border p-1 text-center space-y-1">
-        <div
-          className={`w-8 h-8 mx-auto rounded-full flex items-center justify-center font-semibold ${scoreColor(
-            score
-          )}`}
-        >
-          {score}
         </div>
       </td>
       <td className="border p-1 text-center">{risk.priority}</td>
@@ -43,11 +40,17 @@ export default function RiskRow({ risk, pid, onDelete }: Props) {
           {risk.dateIdentified ? risk.dateIdentified.split('T')[0] : ''}
           {risk.dateResolved && (
             <>
-              {' → '}
+              {' \u2192 '}
               {risk.dateResolved.split('T')[0]}
             </>
           )}
         </div>
+        <div className="text-xs text-gray-500">
+          Reviewed: {risk.lastReviewed.split('T')[0]}
+        </div>
+        {lastNote && (
+          <div className="text-xs italic text-gray-500">{lastNote}</div>
+        )}
       </td>
       <td className="border p-1 space-x-2 whitespace-nowrap">
         <Link href={`/project/${pid}/risk/${risk.id}`} className="text-blue-600">

--- a/src/pages/project/[pid]/index.tsx
+++ b/src/pages/project/[pid]/index.tsx
@@ -327,8 +327,6 @@ export default function ProjectHome() {
           <table className="w-full border rounded">
             <thead>
               <tr className="bg-gray-100">
-                <th className="border p-1">ID</th>
-                <th className="border p-1">Risk</th>
                 <th className="border p-1">
                   <div
                     className="flex items-center justify-center relative"
@@ -360,6 +358,7 @@ export default function ProjectHome() {
                     )}
                   </div>
                 </th>
+                <th className="border p-1">Risk</th>
                 <th className="border p-1">Priority</th>
                 <th className="border p-1">Status / Dates</th>
                 <th className="border p-1">Actions</th>

--- a/src/pages/project/[pid]/risk/[id].tsx
+++ b/src/pages/project/[pid]/risk/[id].tsx
@@ -33,12 +33,14 @@ export default function ManageRisk() {
     const saved = typeof window !== 'undefined' && localStorage.getItem('projects');
     if (!saved) {
       setForm(emptyForm);
+      setStatusNote('');
       return;
     }
     const projects: Project[] = JSON.parse(saved);
     const proj = projects.find((p) => p.id === pid);
     if (!proj) {
       setForm(emptyForm);
+      setStatusNote('');
       return;
     }
     setRisks(proj.risks);
@@ -49,22 +51,23 @@ export default function ManageRisk() {
         const {
           id: discardId,
           lastReviewed: discardLast,
-          statusHistory: discardHistory,
+          statusHistory,
           ...rest
         } = risk;
         void discardId;
         void discardLast;
-        void discardHistory;
         setForm({
           ...emptyForm,
           ...rest,
           dateIdentified: rest.dateIdentified || new Date().toISOString(),
           dateResolved: rest.dateResolved || '',
         });
+        setStatusNote(statusHistory[statusHistory.length - 1]?.note || '');
         return;
       }
     }
     setForm(emptyForm);
+    setStatusNote('');
   }, [router.isReady, pid, id]);
 
   const saveRisks = (items: Risk[]) => {


### PR DESCRIPTION
## Summary
- persist and display last status note in risk form
- show last reviewed date in the risk register rows
- move criticality column first and drop ID column from register

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d3b9aaa388325825411c0087565d5